### PR TITLE
Corrected bug where we weren't getting average notes for level 1 keywords

### DIFF
--- a/queries/getFilteredPoiByKeyword1.js
+++ b/queries/getFilteredPoiByKeyword1.js
@@ -8,7 +8,8 @@ picture.url as picurl,
 user.name as author, 
 grades.accessibility, 
 grades.condition, 
-grades.functional 
+grades.functional,
+ROUND((grades.accessibility + grades.condition + grades.functional)/3) AS 'average'
 from point_of_interest p 
 JOIN poi_keywords pk ON pk.poi_id=p.id 
 JOIN keyword_hierarchy h ON h.keyword_children=pk.keyword_id 


### PR DESCRIPTION
average rating was "empty" when checking poi information after a search from the search bar due to missing arguments in sql query =>corrected.